### PR TITLE
Enable umlauts in German dates

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -347,6 +347,7 @@ def test_date_en_long_to_iso_exceptions():
     # valid input:
     ('4. Jul. 1776', '1776-07-04'),
     ('8. Mai 1945', '1945-05-08'),
+    ('15. März 2021', '2021-03-15'),
     ('3. Oktober 1990', '1990-10-03'),
     ('03. November 2020', '2020-11-03'),
     # messed up whitespace:

--- a/userprovided/date.py
+++ b/userprovided/date.py
@@ -91,7 +91,7 @@ def date_de_long_to_iso(date_string: str) -> str:
        (i.e. YYYY-MM-DD). """
     date_string = date_string.strip()
     regex_long_date_de = re.compile(
-        r"(?P<day>\d{1,2})\.\s+(?P<monthL>[a-zA-ZÄä\.]{3,9})\s+(?P<year>\d{4})"
+        r"(?P<day>\d{1,2})\.\s+(?P<monthL>[a-zA-ZÄä\.]{3,9})\s+(?P<year>\d{4})")
     try:
         match = re.search(regex_long_date_de, date_string)
         if match:

--- a/userprovided/date.py
+++ b/userprovided/date.py
@@ -91,7 +91,7 @@ def date_de_long_to_iso(date_string: str) -> str:
        (i.e. YYYY-MM-DD). """
     date_string = date_string.strip()
     regex_long_date_de = re.compile(
-        r"(?P<day>\d{1,2})\.\s+(?P<monthL>[a-zA-Z\.]{3,9})\s+(?P<year>\d\d\d\d)")
+        r"(?P<day>\d{1,2})\.\s+(?P<monthL>[a-zA-ZÄä\.]{3,9})\s+(?P<year>\d{4})"
     try:
         match = re.search(regex_long_date_de, date_string)
         if match:


### PR DESCRIPTION
## Summary
- update German date regex to only allow umlaut 'Ä'
- keep test for `März`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_684e001e04848333b5654206399b735b